### PR TITLE
ci: builds AppImage bundles for x86_64 and aarch64 with zsync updates…

### DIFF
--- a/.github/workflows/package-appimage.sh
+++ b/.github/workflows/package-appimage.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Build an AppImage + .zsync for ArcherBC2 (AppImageUpdate-compatible).
+#
+# Usage: package-appimage.sh <source_dir> <arch_suffix> [app_version]
+#   source_dir   — directory with profedit.jar, update.jar, skins/, etc.
+#   arch_suffix  — x86_64 | aarch64
+#   app_version  — version string; falls back to <source_dir>/version.txt or "0.0.0"
+#
+# When GITHUB_REPOSITORY is set the AppImage is built with gh-releases-zsync
+# update info and a .zsync sidecar is generated alongside the AppImage.
+set -euo pipefail
+
+SOURCE_DIR="${1:?Usage: package-appimage.sh <source_dir> <arch_suffix> [app_version]}"
+ARCH_SUFFIX="${2:?}"
+APP_VERSION="${3:-}"
+
+APP_NAME="ArcherBC2"
+APP_ID="archerbc2"
+APPIMAGE_TOOL_URL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH_SUFFIX}.AppImage"
+
+# Resolve version
+if [ -z "$APP_VERSION" ]; then
+  if [ -f "$SOURCE_DIR/version.txt" ]; then
+    APP_VERSION="$(cat "$SOURCE_DIR/version.txt")"
+  else
+    APP_VERSION="0.0.0"
+  fi
+fi
+
+APPIMAGE_FILENAME="${APP_NAME}-${APP_VERSION}-${ARCH_SUFFIX}.AppImage"
+
+# zsync / update-info (only when running in GitHub Actions or GITHUB_REPOSITORY is set)
+REPO_SLUG="${GITHUB_REPOSITORY:-}"
+if [ -n "$REPO_SLUG" ]; then
+  OWNER="${REPO_SLUG%%/*}"
+  REPO="${REPO_SLUG##*/}"
+  UPDATE_INFO="gh-releases-zsync|${OWNER}|${REPO}|latest|${APPIMAGE_FILENAME}.zsync"
+  ZSYNC_URL="https://github.com/${REPO_SLUG}/releases/latest/download/${APPIMAGE_FILENAME}"
+else
+  UPDATE_INFO=""
+  ZSYNC_URL=""
+  echo "WARNING: GITHUB_REPOSITORY not set — building without zsync update info"
+fi
+
+mkdir -p artifacts/appimage
+
+# ── appimagetool ──────────────────────────────────────────────────────────────
+if [ ! -x /tmp/appimagetool ]; then
+  echo "Downloading appimagetool (${ARCH_SUFFIX})..."
+  curl -fsSL "$APPIMAGE_TOOL_URL" -o /tmp/appimagetool
+  chmod +x /tmp/appimagetool
+fi
+
+# ── AppDir ────────────────────────────────────────────────────────────────────
+APPDIR="$(mktemp -d /tmp/AppDir.XXXXXX)"
+trap 'rm -rf "$APPDIR"' EXIT
+
+APP_SHARE="$APPDIR/usr/share/$APP_ID"
+mkdir -p "$APP_SHARE"
+mkdir -p "$APPDIR/usr/share/applications"
+mkdir -p "$APPDIR/usr/share/icons/hicolor/256x256/apps"
+
+# Application payload
+cp "$SOURCE_DIR/profedit.jar" "$APP_SHARE/"
+[ -f "$SOURCE_DIR/update.jar" ]                    && cp "$SOURCE_DIR/update.jar" "$APP_SHARE/"
+[ -d "$SOURCE_DIR/skins" ]                         && cp -r "$SOURCE_DIR/skins" "$APP_SHARE/"
+[ -f "$SOURCE_DIR/a7p-associations.properties" ]   && cp "$SOURCE_DIR/a7p-associations.properties" "$APP_SHARE/"
+
+# Icon — search common locations
+ICON_SRC=""
+for candidate in \
+  "$SOURCE_DIR/icon.png" \
+  "icon.png" \
+  "assets/icon.png" \
+  "../icon.png"
+do
+  if [ -f "$candidate" ]; then
+    ICON_SRC="$candidate"
+    break
+  fi
+done
+
+ICON_DEST="$APPDIR/usr/share/icons/hicolor/256x256/apps/${APP_ID}.png"
+if [ -n "$ICON_SRC" ]; then
+  cp "$ICON_SRC" "$ICON_DEST"
+  echo "icon: $ICON_SRC"
+else
+  # Minimal 1x1 transparent PNG fallback so appimagetool does not abort
+  printf '\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82' \
+    > "$ICON_DEST"
+  echo "WARNING: no icon found — using 1x1 placeholder"
+fi
+
+# Desktop file
+cat > "$APPDIR/usr/share/applications/${APP_ID}.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=${APP_NAME}
+Exec=AppRun %f
+Icon=${APP_ID}
+Comment=A professional editor for A7P profiles
+Categories=Utility;
+MimeType=application/x-a7p;
+X-AppImage-Version=${APP_VERSION}
+EOF
+
+# Root symlinks required by the AppImage spec
+ln -sf "usr/share/applications/${APP_ID}.desktop" "$APPDIR/${APP_ID}.desktop"
+ln -sf "usr/share/icons/hicolor/256x256/apps/${APP_ID}.png" "$APPDIR/${APP_ID}.png"
+ln -sf "usr/share/icons/hicolor/256x256/apps/${APP_ID}.png" "$APPDIR/.DirIcon"
+
+# AppRun
+cat > "$APPDIR/AppRun" <<'APPRUN'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "$0")")"
+exec java -jar "$HERE/usr/share/archerbc2/profedit.jar" "$@"
+APPRUN
+chmod +x "$APPDIR/AppRun"
+
+# ── Build AppImage ─────────────────────────────────────────────────────────────
+APPIMAGE_OUT="artifacts/appimage/${APPIMAGE_FILENAME}"
+echo "Building ${APPIMAGE_FILENAME}..."
+if [ -n "$UPDATE_INFO" ]; then
+  ARCH="${ARCH_SUFFIX}" /tmp/appimagetool --updateinformation "$UPDATE_INFO" "$APPDIR" "$APPIMAGE_OUT"
+else
+  ARCH="${ARCH_SUFFIX}" /tmp/appimagetool "$APPDIR" "$APPIMAGE_OUT"
+fi
+echo "AppImage: $APPIMAGE_OUT"
+
+# ── .zsync sidecar ────────────────────────────────────────────────────────────
+if [ -n "$ZSYNC_URL" ]; then
+  if command -v zsyncmake &>/dev/null; then
+    zsyncmake -u "$ZSYNC_URL" -o "${APPIMAGE_OUT}.zsync" "$APPIMAGE_OUT"
+    echo "zsync:    ${APPIMAGE_OUT}.zsync"
+  else
+    echo "WARNING: zsyncmake not found — install the 'zsync' package (apt install zsync)"
+  fi
+fi
+
+echo ""
+ls -lh artifacts/appimage/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Clojure CI
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   download_firmware:
@@ -10,23 +11,31 @@ jobs:
     timeout-minutes: 1
 
     strategy:
+      fail-fast: false
       matrix:
         firmware:
           - {name: "Archer FALCON", version: "0.39"}
           - {name: "Archer TSA-10/40", version: "0.59"}
-          - {name: "Archer TSA-9/75 (640)", version: "0.85"}
-          - {name: "Archer TSA-9/75-640", version: "0.85"}
-          - {name: "Archer TSA-9/75", version: "0.85"}
+          - {name: "Archer TSA-9/75 (640)", version: "0.85"}
+          - {name: "Archer TSA-9/75-640", version: "0.85"}
+          - {name: "Archer TSA-9/75", version: "0.85"}
           - {name: "Archer TSA-9", version: "0.85"}
           - {name: "Archer TSC-10LRF/50-640", version: "0.39"}
           - {name: "Archer TSA-11/25", version: "0.58"}
 
     steps:
     - name: Fetch firmware using SigV4 signed request
+      id: fetch_firmware
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       run: |
+        if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+          echo "::warning::AWS credentials not available – skipping firmware download"
+          echo "fetched=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         # Encoding to base64 and then converting to URL-safe
         encoded_name=$(echo -n "${{ matrix.firmware.name }}" | base64 | tr '+/' '-_')
         encoded_version=$(echo -n "${{ matrix.firmware.version }}" | base64 | tr '+/' '-_')
@@ -45,8 +54,10 @@ jobs:
         # Export encoded values for artifact naming
         echo "ENCODED_NAME=$encoded_name" >> $GITHUB_ENV
         echo "ENCODED_VERSION=$encoded_version" >> $GITHUB_ENV
+        echo "fetched=true" >> $GITHUB_OUTPUT
 
     - name: Upload firmware as artifact
+      if: steps.fetch_firmware.outputs.fetched == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: firmware-${{ env.ENCODED_NAME }}-${{ env.ENCODED_VERSION }}
@@ -55,12 +66,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     needs: download_firmware
+    if: always() && needs.download_firmware.result != 'cancelled'
     timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Download all firmware artifacts
+      continue-on-error: true
       uses: actions/download-artifact@v4
       with:
         pattern: firmware-*
@@ -145,6 +158,45 @@ jobs:
       release_tag: ${{ env.RELEASE_TAG }}
       win32_zip_name: ${{ env.WIN32_ZIP_NAME }}
 
+  linux_appimage:
+    runs-on: ${{ matrix.runner }}
+    needs: build
+    timeout-minutes: 10
+
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-22.04
+          - arch: aarch64
+            runner: ubuntu-22.04-arm
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: package-artifacts
+          path: .
+
+      - name: Convert icon
+        run: convert .github/workflows/icon.ico[0] -resize 256x256 icon.png
+
+      - name: Install zsync
+        run: sudo apt-get install -y zsync
+
+      - name: Build AppImage + zsync
+        run: |
+          chmod +x .github/workflows/package-appimage.sh
+          .github/workflows/package-appimage.sh . ${{ matrix.arch }} "${{ needs.build.outputs.release_tag }}"
+
+      - name: Upload AppImage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: appimage-${{ matrix.arch }}
+          path: artifacts/appimage/
+
   setup_innosetup:
     needs: build
     runs-on: windows-latest
@@ -171,13 +223,13 @@ jobs:
         $Env:SRC="${{ github.workspace }}\src"
         & "$Env:ISCC_PATH" /Qp "${{ github.workspace }}\.github\workflows\install.iss"
       shell: pwsh
-      
+
     - name: Debug file structure
       run: |
         cd ./src
         Get-ChildItem
       shell: pwsh
-      
+
     - name: Copy installer
       run: |
         Copy-Item "${{ github.workspace }}\src\ArcherBC2_install.exe" "${{ github.workspace }}\"
@@ -191,7 +243,8 @@ jobs:
           ArcherBC2_install.exe
 
   release:
-    needs: [build, setup_innosetup]
+    if: github.event_name == 'push' && !github.event.repository.fork
+    needs: [build, setup_innosetup, linux_appimage]
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     permissions:
@@ -209,6 +262,18 @@ jobs:
         name: inno-setup-artifact
         path: ./Output
 
+    - name: Download x86_64 AppImage
+      uses: actions/download-artifact@v4
+      with:
+        name: appimage-x86_64
+        path: ./AppImage
+
+    - name: Download aarch64 AppImage
+      uses: actions/download-artifact@v4
+      with:
+        name: appimage-aarch64
+        path: ./AppImage
+
     - name: Create a Release
       uses: meeDamian/github-release@2.0
       with:
@@ -219,4 +284,8 @@ jobs:
           ./src/${{ needs.build.outputs.win32_zip_name }}
           ./src/profedit.jar
           ./Output/ArcherBC2_install.exe
+          ./AppImage/ArcherBC2-${{ needs.build.outputs.release_tag }}-x86_64.AppImage
+          ./AppImage/ArcherBC2-${{ needs.build.outputs.release_tag }}-x86_64.AppImage.zsync
+          ./AppImage/ArcherBC2-${{ needs.build.outputs.release_tag }}-aarch64.AppImage
+          ./AppImage/ArcherBC2-${{ needs.build.outputs.release_tag }}-aarch64.AppImage.zsync
         allow_override: true


### PR DESCRIPTION
### Added
- Linux AppImage packages for `x86_64` and `aarch64` architectures built via CI
- `.zsync` sidecar files alongside each AppImage for delta updates via AppImageUpdate
- `gh-releases-zsync` update info embedded in AppImages pointing to the latest GitHub release
- `workflow_dispatch` trigger for manual (debug) CI runs without creating a release

### Changed
- `download_firmware` matrix now uses `fail-fast: false` — a single firmware failure no longer cancels the entire matrix
- Firmware download gracefully skips with a warning when AWS credentials are unavailable (e.g. forks)
- `build` job runs even when firmware download was skipped — firmware artifacts are optional
- Release is created only on `push` to `main` on the origin repository, not on forks
